### PR TITLE
fix: link style when line-breaking

### DIFF
--- a/style.css
+++ b/style.css
@@ -399,17 +399,7 @@ a {
   text-decoration-thickness: 2px;
   text-underline-offset: var(--offset, 0.1em);
   transition: text-decoration-color 0.2s, --offset 0.2s;
-  position: relative;
-}
-a::before {
-  content: "";
-  position: absolute;
-  top: 0.5em;
-  bottom: 0;
-  left: 4px;
-  right: -4px;
-  z-index: -1;
-  background-color: var(--link-bg-color, #deefff);
+  box-shadow: 0 -0.7em var(--link-bg-color, #deefff) inset;
 }
 a:hover {
   cursor: pointer;
@@ -592,9 +582,9 @@ td {
 footer a {
   color: inherit;
 }
-.home a::before,
-footer a::before {
-  background-color: transparent;
+.home a,
+footer a {
+  box-shadow: unset;
 }
 .home a:hover,
 .home a:focus,


### PR DESCRIPTION
before:
<img width="669" alt="image" src="https://github.com/hyrious/hyrious.github.io/assets/33192552/0fa4c806-3b4d-4d4a-8d11-d8b56940cf4d">

after:
<img width="680" alt="image" src="https://github.com/hyrious/hyrious.github.io/assets/33192552/1ab3518a-8727-4d9b-8587-5f07d4deffff">
